### PR TITLE
Update start & open times to be times

### DIFF
--- a/scrape_from_the_ape/utils/brunswick_green_helpers.py
+++ b/scrape_from_the_ape/utils/brunswick_green_helpers.py
@@ -4,7 +4,7 @@ Desc: A collection of utility functions to organise parsing of Open Studio
 """
 
 import requests
-from datetime import datetime
+from datetime import datetime, timedelta
 from scrape_from_the_ape.items import *
 
 BASE_URL = "https://thebrunswickgreen.com"
@@ -27,8 +27,10 @@ def brunswick_green_event_parser(gig: dict) -> ScrapeFromTheApeItem:
     item = ScrapeFromTheApeItem()
 
     item["title"] = gig["title"]
-    item["music_starts"] = start_datetime.strftime("%Y-%m-%d %H:%M:%S")
-    item["doors_open"] = start_datetime.strftime("%Y-%m-%d")
+    item["music_starts"] = start_datetime.strftime("%H:%M")
+
+    # Assume doors open 30min before music starts
+    item["doors_open"] = (start_datetime - timedelta(minutes=30)).strftime("%H:%M")
     item["performance_date"] = start_datetime.strftime("%Y-%m-%d")
     item["price"] = 0.00  # no prices in API, gig page, or when following ticket links 😟
     item["description"] = get_description(gig_url)


### PR DESCRIPTION
Start time & doors open were saved as dates & datetimes but we need them to be just times. Thus, two changes were made:
1. `start_time` dumps the date component as this is redundant being in the `performance_date` field and also it brings it into line with the other venues.
2. `doors_open` defaults to 30min earlier than `start_time` because no time is returned in the Brunswick Green API call.